### PR TITLE
🔧 Fix NextAuth TypeScript error: remove refetchWhenOffline prop

### DIFF
--- a/src/providers/SessionProvider.tsx
+++ b/src/providers/SessionProvider.tsx
@@ -7,7 +7,6 @@ export function SessionProvider({ children, session }: { children: React.ReactNo
     <NextAuthSessionProvider
       session={session}
       refetchOnWindowFocus={true}
-      refetchWhenOffline={true}
       refetchInterval={30}
     >
       {children}


### PR DESCRIPTION
- NextAuth refetchWhenOffline type only accepts 'false' or undefined
- Removing the prop enables the behavior by default without type errors
- Resolves 'Type true is not assignable to type false' build error